### PR TITLE
Fixed compile error

### DIFF
--- a/examples/seven-segement/seven-segement.ino
+++ b/examples/seven-segement/seven-segement.ino
@@ -25,8 +25,8 @@ void setup() {
 
 void loop() {
     uint8_t codes[2];
-    code[0] = NUMBER_CODES[number / 10];
-    code[1] = NUMBER_CODES[number % 10];
+    codes[0] = NUMBER_CODES[number / 10];
+    codes[1] = NUMBER_CODES[number % 10];
     driver.writeDisplay(codes, 0, sizeof(codes));
     number++;
     if (number >= 100) {


### PR DESCRIPTION
The variable `code` did not exist and ought to be `codes`. This commit fixes that.